### PR TITLE
Filter Conversation Script

### DIFF
--- a/filter-conversations.py
+++ b/filter-conversations.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+
+if len(sys.argv) < 2:
+   print(f"usage: {sys.argv[0]} CONFIG.JSON", file=sys.stderr)
+   sys.exit(1)
+
+with open(sys.argv[1]) as f:
+   config = json.load(f)
+
+curr_convo = []
+skip_convo = False
+
+for _line in sys.stdin:
+   line = _line.rstrip()
+   line_words = line.split(" ")
+
+   if line == "": # signals end of convo
+      if not skip_convo and len(curr_convo) != 0:
+         print('\n'.join(curr_convo) + "\n")
+      skip_convo = False
+      curr_convo = []
+   elif not skip_convo:
+      curr_convo.append(line)
+      if line_words[0] == "TERM:":
+         term = " ".join(line_words[1:])
+         if term not in config['words'] or term in config['exclude']:
+            skip_convo = True


### PR DESCRIPTION
`filter-conversations.py` reads generated chat data from `stdin` and outputs valid conversations to `stdout`. Valid conversations are defined in a `config.json` file which is passed in as a command line argument to the script. Specifically, it will look for an array of strings called `words` of terms to include and an array of strings called `exclude` of words to exclude. 

Conversations need to have a line in them that states the topic of the conversations in this format: `TERM: topic...`. Any without it will be excluded from output. Conversations should be separated with a blank newline.

Here is an example usage:
```console
cat conv.txt | python filter-conversation.py filter.json >> conv-filtered.txt
```