### PR TITLE
Saves More Conversation Output & Additional Arguments Passed to Llama

### DIFF
--- a/get-word-conversations.py
+++ b/get-word-conversations.py
@@ -50,7 +50,8 @@ for word in config['words']:
 		print(f"skipping {word}", file=sys.stderr)
 		continue
 	print(f"processing {word}", file=sys.stderr)
-	p = Popen(["./main", "--log-disable", "--escape", "-m", model, "-p",  prompt.format(word = word)], stdout=PIPE, stderr=DEVNULL, encoding="utf-8")
+	args = ["./main", "--log-disable", "--escape", "-m", model, "-p", prompt.format(word = word)] + sys.argv[2:]
+	p = Popen(args, stdout=PIPE, stderr=DEVNULL, encoding="utf-8")
 
 	lines = []
 

--- a/get-word-conversations.py
+++ b/get-word-conversations.py
@@ -69,8 +69,14 @@ for word in config['words']:
 
 		if line.find(':') < 0:
 			print(f"ending early {word} with: {line}", file=sys.stderr)
-			lines = []
-			break
+
+			if line == '':
+				print(f"saving entire conversation for {word}", file=sys.stderr)
+				break
+			else:
+				lines = lines[:1]
+				print(f"saving question & term for {word}", file=sys.stderr)
+				break
 
 		if re.search(exwords_re, line, re.IGNORECASE):
 			print(f"has excluded word {word}", file=sys.stderr)


### PR DESCRIPTION
First, behavior when encountering "incorrect" lines has changed. Whenever an improperly formatted line is encountered, either the entire conversation or just the question is saved to output. When the line in question is a blank newline, the conversation is okay to keep, otherwise only the question is saved. This change noticeably increases the output rate of conversations.

Below is an example of saving an entire conversation followed by saving just the question.
```console
processing background radiation
ending early background radiation with:
saving entire conversation for background radiation
STUDENT: Can you explain the term 'background radiation'?
TERM: background radiation
TEACHER: Sure. In the context of the Big Bang theory, background radiation refers to ...
...
processing elementary particle
ending early elementary particle with: The student walked away with a ...
saving question & term for elementary particle
STUDENT: What does it mean when someone talks about elementary particles?
TERM: elementary particle
...
```

Second, additional python script arguments will automatically be passed as runtime arguments to Llama instances. 

For example, the following passes `-ngl 1000`:
```console
python get-word-conversations.py config.json -ngl 1000 >> /tmp/conv.txt
```